### PR TITLE
Fix the path for the mirror'd misc repo

### DIFF
--- a/templates/registries.conf.j2
+++ b/templates/registries.conf.j2
@@ -23,7 +23,7 @@ unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']
   prefix = ""
 
   [[registry.mirror]]
-    location = "{{ mirror_endpoint }}/{{ reg.split('/')[1:] | join('/') }}"
+    location = "{{ mirror_endpoint }}/{{ misc_image_path }}/{{ reg.split('/')[1:] | join('/') }}"
     insecure = false
 
 {% endfor %}
@@ -38,7 +38,7 @@ unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']
   prefix = ""
 
   [[registry.mirror]]
-    location = "{{ mirror_endpoint }}/olm/{{ reg.split('/')[1:] | join('/') }}"
+    location = "{{ mirror_endpoint }}/{{ olm_image_path }}/{{ reg.split('/')[1:] | join('/') }}"
     insecure = false
 
 {% endfor %}


### PR DESCRIPTION
This template pushes out a customised registries.conf to the cluster
nodes. The path for the misc images was missing `/misc/`. Added the
same.
Also the path for the olm images was statically defined as `/olm/`
Made sure both paths are referenced using their corresponding variables.